### PR TITLE
Bug: music.youtube.com is broken with the chrome extension loaded. It

### DIFF
--- a/utils/makeManifestGenerator.js
+++ b/utils/makeManifestGenerator.js
@@ -2,7 +2,7 @@ const GenerateJsonFile = require('generate-json-file-webpack-plugin');
 
 const FB_MATCHES = ['*://*.facebook.com/*'];
 const FB_EXCLUDES = ['*://*.facebook.com/ads/archive*', '*://*.facebook.com/ads/library*'];
-const YT_MATCHES = ['*://*.youtube.com/*'];
+const YT_MATCHES = ['*://www.youtube.com/*'];
 const BASE_MANIFEST = {
   manifest_version: 2,
   homepage_url: 'https://github.com/AlgorithmicTransparencyInstitute/social-media-collector',


### PR DESCRIPTION
does not play music.

Fix: do not load extension on music.youtube.com domain because we are
not interested in the ads being shown there.